### PR TITLE
improvement merge

### DIFF
--- a/Editor/AssetbundleBuildProcessors.cs
+++ b/Editor/AssetbundleBuildProcessors.cs
@@ -19,7 +19,7 @@ namespace BundleSystem
             if (!Directory.Exists(Application.streamingAssetsPath)) Directory.CreateDirectory(Application.streamingAssetsPath);
 
 
-            var localBundleSourcePath = Path.Combine(settings.LocalOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString());
+            var localBundleSourcePath = Utility.CombinePath(settings.LocalOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString());
             if(!Directory.Exists(localBundleSourcePath))
             {
                 if(Application.isBatchMode)
@@ -35,7 +35,7 @@ namespace BundleSystem
                 }
             }
 
-            FileUtil.CopyFileOrDirectory(Path.Combine(settings.LocalOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString()), AssetbundleBuildSettings.LocalBundleRuntimePath);
+            FileUtil.CopyFileOrDirectory(Utility.CombinePath(settings.LocalOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString()), AssetbundleBuildSettings.LocalBundleRuntimePath);
             AssetDatabase.Refresh();
         }
 

--- a/Editor/AssetbundleBuildSettingsInspector.cs
+++ b/Editor/AssetbundleBuildSettingsInspector.cs
@@ -108,11 +108,11 @@ namespace BundleSystem
 
             GUILayout.BeginHorizontal();
             EditorGUILayout.PropertyField(m_RemoteOutputPath);
-            if (GUILayout.Button("Open", GUILayout.ExpandWidth(false))) EditorUtility.RevealInFinder(Path.Combine(settings.RemoteOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString()));
+            if (GUILayout.Button("Open", GUILayout.ExpandWidth(false))) EditorUtility.RevealInFinder(Utility.CombinePath(settings.RemoteOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString()));
             GUILayout.EndHorizontal();
             GUILayout.BeginHorizontal();
             EditorGUILayout.PropertyField(m_LocalOutputPath);
-            if (GUILayout.Button("Open", GUILayout.ExpandWidth(false))) EditorUtility.RevealInFinder(Path.Combine(settings.LocalOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString()));
+            if (GUILayout.Button("Open", GUILayout.ExpandWidth(false))) EditorUtility.RevealInFinder(Utility.CombinePath(settings.LocalOutputPath, EditorUserBuildSettings.activeBuildTarget.ToString()));
             GUILayout.EndHorizontal();
             EditorGUILayout.PropertyField(m_RemoteURL);
             EditorGUILayout.Space();

--- a/Editor/AssetbundleBuilder.cs
+++ b/Editor/AssetbundleBuilder.cs
@@ -62,6 +62,18 @@ namespace BundleSystem
 
         public static void WriteExpectedSharedBundles(AssetbundleBuildSettings settings)
         {
+            if(!Application.isBatchMode)
+            {
+                //have to ask save current scene
+                var saved = UnityEditor.SceneManagement.EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo();
+
+                if(!saved) 
+                {
+                    EditorUtility.DisplayDialog("Failed!", $"User Canceled", "Confirm");
+                    return;
+                }
+            }
+            
             var bundleList = GetAssetBundlesList(settings);
             var treeResult = AssetDependencyTree.ProcessDependencyTree(bundleList);
             WriteSharedBundleLog($"{Application.dataPath}/../", treeResult);
@@ -100,12 +112,24 @@ namespace BundleSystem
 
         public static void BuildAssetBundles(AssetbundleBuildSettings settings, BuildType buildType)
         {
+            if(!Application.isBatchMode)
+            {
+                //have to ask save current scene
+                var saved = UnityEditor.SceneManagement.EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo();
+
+                if(!saved) 
+                {
+                    EditorUtility.DisplayDialog("Build Failed!", $"User Canceled", "Confirm");
+                    return;
+                }
+            }
+
             var bundleList = GetAssetBundlesList(settings);
 
             var buildTarget = EditorUserBuildSettings.activeBuildTarget;
             var groupTarget = BuildPipeline.GetBuildTargetGroup(buildTarget);
 
-            var outputPath = Path.Combine(buildType == BuildType.Local ? settings.LocalOutputPath : settings.RemoteOutputPath, buildTarget.ToString());
+            var outputPath = Utility.CombinePath(buildType == BuildType.Local ? settings.LocalOutputPath : settings.RemoteOutputPath, buildTarget.ToString());
 
 
             //generate sharedBundle if needed, and pre generate dependency
@@ -245,7 +269,7 @@ namespace BundleSystem
             manifest.BuildTime = DateTime.UtcNow.Ticks;
             manifest.RemoteURL = remoteURL;
             if (!Directory.Exists(path)) Directory.CreateDirectory(path);
-            File.WriteAllText(Path.Combine(path, AssetbundleBuildSettings.ManifestFileName), JsonUtility.ToJson(manifest, true));
+            File.WriteAllText(Utility.CombinePath(path, AssetbundleBuildSettings.ManifestFileName), JsonUtility.ToJson(manifest, true));
         }
 
         static void WriteSharedBundleLog(string path, AssetDependencyTree.ProcessResult treeResult)
@@ -273,7 +297,7 @@ namespace BundleSystem
             }
 
             if (!Directory.Exists(path)) Directory.CreateDirectory(path);
-            File.WriteAllText(Path.Combine(path, LogExpectedSharedBundleFileName), sb.ToString());
+            File.WriteAllText(Utility.CombinePath(path, LogExpectedSharedBundleFileName), sb.ToString());
         }
 
 
@@ -318,7 +342,7 @@ namespace BundleSystem
             }
 
             if (!Directory.Exists(path)) Directory.CreateDirectory(path);
-            File.WriteAllText(Path.Combine(path, LogFileName), sb.ToString());
+            File.WriteAllText(Utility.CombinePath(path, LogFileName), sb.ToString());
         }
     }
 }

--- a/Editor/AssetbundleUploader.cs
+++ b/Editor/AssetbundleUploader.cs
@@ -14,8 +14,8 @@ namespace BundleSystem
             {
                 var buildTargetString = EditorUserBuildSettings.activeBuildTarget.ToString();
                 var credential = new NetworkCredential(settings.FtpUserName, settings.FtpUserPass);
-                var uploadRootPath = Path.Combine(settings.FtpHost, buildTargetString);
-                var dirInfo = new DirectoryInfo(Path.Combine(settings.RemoteOutputPath, buildTargetString));
+                var uploadRootPath = Utility.CombinePath(settings.FtpHost, buildTargetString);
+                var dirInfo = new DirectoryInfo(Utility.CombinePath(settings.RemoteOutputPath, buildTargetString));
                 var files = dirInfo.GetFiles();
                 var progress = 0f;
                 var progressStep = 1f / files.Length;
@@ -23,7 +23,7 @@ namespace BundleSystem
                 {
                     byte[] data = File.ReadAllBytes(fileInfo.FullName);
                     EditorUtility.DisplayProgressBar("Uploading AssetBundles", fileInfo.Name, progress);
-                    FtpUpload(Path.Combine(uploadRootPath, fileInfo.Name), data, credential);
+                    FtpUpload(Utility.CombinePath(uploadRootPath, fileInfo.Name), data, credential);
                     progress += progressStep;
                 }
             }

--- a/Runtime/AssetbundleUtilities.cs
+++ b/Runtime/AssetbundleUtilities.cs
@@ -130,13 +130,12 @@ namespace BundleSystem
         public static string CombinePath(params string[] args)
         {
             var sb = new System.Text.StringBuilder();
-            var prevHasSeperateChar = true;
             for(int i = 0; i < args.Length; i++)
             {
-                if(!prevHasSeperateChar) sb.Append('/');
-                var toAppend = args[i].TrimStart('/');
-                prevHasSeperateChar = toAppend.EndsWith("/");
-                sb.Append(toAppend);
+                //skip empty
+                if(string.IsNullOrEmpty(args[i])) continue;
+                if(sb.Length > 0) sb.Append('/');
+                sb.Append(args[i]);
             }
             return sb.ToString();
         }

--- a/Runtime/AssetbundleUtilities.cs
+++ b/Runtime/AssetbundleUtilities.cs
@@ -87,7 +87,7 @@ namespace BundleSystem
             var sceneInfo = UnityEditor.Build.Content.ContentBuildInterface.CalculatePlayerDependenciesForScene(scenePath, settings, usageTags, depsCache);
 #else
             Directory.CreateDirectory(kTempBuildPath);
-            var ceneInfo = UnityEditor.Build.Content.ContentBuildInterface.PrepareScene(scenePath, settings, usageTags, depsCache, outputFolder);
+            var sceneInfo = UnityEditor.Build.Content.ContentBuildInterface.PrepareScene(scenePath, settings, usageTags, depsCache, kTempBuildPath);
 #endif
 
             //this is needed as calculate function actumatically pops up progress bar

--- a/Runtime/BundleManager.cs
+++ b/Runtime/BundleManager.cs
@@ -68,7 +68,7 @@ namespace BundleSystem
             LocalURL = AssetbundleBuildSettings.LocalBundleRuntimePath;
 #if UNITY_EDITOR
             SetupAssetdatabaseUsage();
-            LocalURL = Path.Combine(s_EditorBuildSettings.LocalOutputPath, UnityEditor.EditorUserBuildSettings.activeBuildTarget.ToString());
+            LocalURL = Utility.CombinePath(s_EditorBuildSettings.LocalOutputPath, UnityEditor.EditorUserBuildSettings.activeBuildTarget.ToString());
 #endif
             if (Application.platform != RuntimePlatform.Android && Application.platform != RuntimePlatform.WebGLPlayer) LocalURL = "file://" + LocalURL;
         }
@@ -111,7 +111,7 @@ namespace BundleSystem
             s_AssetBundles.Clear();
             s_LocalBundles.Clear();
 
-            var manifestReq = UnityWebRequest.Get(Path.Combine(LocalURL, AssetbundleBuildSettings.ManifestFileName));
+            var manifestReq = UnityWebRequest.Get(Utility.CombinePath(LocalURL, AssetbundleBuildSettings.ManifestFileName));
             yield return manifestReq.SendWebRequest();
             if (manifestReq.isHttpError || manifestReq.isNetworkError)
             {
@@ -144,7 +144,7 @@ namespace BundleSystem
                     !Caching.IsVersionCached(cachedBundleInfo.AsCached); //is not cached no unusable.
 
                 bundleInfoToLoad = useLocalBundle ? localBundleInfo : cachedBundleInfo;
-                var loadPath = Path.Combine(LocalURL, bundleInfoToLoad.BundleName);
+                var loadPath = Utility.CombinePath(LocalURL, bundleInfoToLoad.BundleName);
 
                 var bundleReq = UnityWebRequestAssetBundle.GetAssetBundle(loadPath, bundleInfoToLoad.Hash);
                 var bundleOp = bundleReq.SendWebRequest();
@@ -172,10 +172,10 @@ namespace BundleSystem
                 s_LocalBundles.Add(localBundleInfo.BundleName, localBundleInfo.Hash);
             }
 
-            RemoteURL = Path.Combine(localManifest.RemoteURL, localManifest.BuildTarget).Replace('\\', '/');
+            RemoteURL = Utility.CombinePath(localManifest.RemoteURL, localManifest.BuildTarget);
 #if UNITY_EDITOR
             if (s_EditorBuildSettings.EmulateWithoutRemoteURL)
-                RemoteURL = "file://" + Path.Combine(s_EditorBuildSettings.RemoteOutputPath, UnityEditor.EditorUserBuildSettings.activeBuildTarget.ToString());
+                RemoteURL = "file://" + Utility.CombinePath(s_EditorBuildSettings.RemoteOutputPath, UnityEditor.EditorUserBuildSettings.activeBuildTarget.ToString());
 #endif
             Initialized = true;
             if (LogMessages) Debug.Log($"Initialize Success \nRemote URL : {RemoteURL} \nLocal URL : {LocalURL}");
@@ -216,7 +216,7 @@ namespace BundleSystem
             }
 #endif
 
-            var manifestReq = UnityWebRequest.Get(Path.Combine(RemoteURL, AssetbundleBuildSettings.ManifestFileName).Replace('\\', '/'));
+            var manifestReq = UnityWebRequest.Get(Utility.CombinePath(RemoteURL, AssetbundleBuildSettings.ManifestFileName).Replace('\\', '/'));
             yield return manifestReq.SendWebRequest();
 
             if (manifestReq.isHttpError || manifestReq.isNetworkError)
@@ -314,7 +314,7 @@ namespace BundleSystem
                 var isCached = Caching.IsVersionCached(bundleInfo.AsCached);
                 result.SetCachedBundle(isCached);
 
-                var loadURL = islocalBundle ? Path.Combine(LocalURL, bundleInfo.BundleName) : Path.Combine(RemoteURL, bundleInfo.BundleName).Replace('\\', '/');
+                var loadURL = islocalBundle ? Utility.CombinePath(LocalURL, bundleInfo.BundleName) : Utility.CombinePath(RemoteURL, bundleInfo.BundleName);
                 if (LogMessages) Debug.Log($"Loading Bundle Name : {bundleInfo.BundleName}, loadURL {loadURL}, isLocalBundle : {islocalBundle}, isCached {isCached}");
                 LoadedBundle previousBundle;
 


### PR DESCRIPTION
properly support 2018 version (It wasn't due to scene dependency collecting)
replaced path.combine to own utility function(this will resolve directorysepratechar difference for some platforms)
when build, if not batchmode, will be asked for saving current dirty scene.